### PR TITLE
Include account id and screen_name into returned lists response. 

### DIFF
--- a/twoopstracker/twoops/serializers.py
+++ b/twoopstracker/twoops/serializers.py
@@ -47,17 +47,26 @@ class TwitterAccountsListsSerializer(serializers.ModelSerializer):
     class Meta:
         model = TwitterAccountsList
         fields = ["id", "name", "created_at", "is_private", "accounts"]
-        extra_kwargs = {
-            "accounts": {"write_only": True},
-        }
+
+    def get_accounts(self, instance):
+        accounts = instance.accounts.all()
+        data = []
+        for account in accounts:
+            data.append(
+                {
+                    "id": account.account_id,
+                    "screen_name": account.screen_name,
+                }
+            )
+        return data
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["accounts"] = self.get_accounts(instance)
+        return data
 
 
 class TwitterAccountsListSerializer(TwitterAccountsListsSerializer):
-    class Meta(TwitterAccountsListsSerializer.Meta):
-        extra_kwargs = {
-            "accounts": {"write_only": False},
-        }
-
     def get_accounts(self, obj):
         accounts = obj.accounts.all()
         data = []
@@ -73,11 +82,6 @@ class TwitterAccountsListSerializer(TwitterAccountsListsSerializer):
                 }
             )
 
-        return data
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        data["accounts"] = self.get_accounts(instance)
         return data
 
 


### PR DESCRIPTION
## Description

From a discussion I had with @gertie-sheshe , the F.E uses a Modal to edit a `List Name` and since for updates the B.E expects accounts to also be there, the F.E would have to make an extra `GET` request to the specific List in order to update it. This PR prevents that by including `account_id` and the `screen_names` required while making an update to a list.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1168" alt="Screenshot 2021-11-29 at 15 38 55" src="https://user-images.githubusercontent.com/13068580/143869627-b8584585-50b0-4f64-9883-ca702d16ce4c.png">

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
