### PR TITLE
Return Twitter accounts belonging to public lists even to non logged-in users

### DIFF
--- a/twoopstracker/twoops/views.py
+++ b/twoopstracker/twoops/views.py
@@ -421,14 +421,18 @@ class AccountsList(generics.RetrieveUpdateDestroyAPIView):
 
 class TwitterAccountsView(generics.ListAPIView):
     serializer_class = TwitterAccountsSerializer
-    permission_classes = [
-        IsAuthenticated,
-    ]
 
     def get_queryset(self):
-        return TwitterAccount.objects.filter(
-            lists__owner=self.request.user.userprofile
-        ).distinct()
+        if self.request.user.is_authenticated:
+            return TwitterAccount.objects.filter(
+                Q(lists__owner=self.request.user.userprofile)
+                | Q(lists__is_private=False)
+                | Q(
+                    lists__teams__members__user_id=self.request.user.userprofile.user_id
+                )
+            ).distinct()
+
+        return TwitterAccount.objects.filter(lists__is_private=False)
 
 
 class TwitterAccountCategoriesView(generics.ListAPIView):

--- a/twoopstracker/twoops/views.py
+++ b/twoopstracker/twoops/views.py
@@ -424,15 +424,14 @@ class TwitterAccountsView(generics.ListAPIView):
 
     def get_queryset(self):
         if self.request.user.is_authenticated:
+            user_profile = self.request.user.userprofile
             return TwitterAccount.objects.filter(
-                Q(lists__owner=self.request.user.userprofile)
-                | Q(lists__is_private=False)
-                | Q(
-                    lists__teams__members__user_id=self.request.user.userprofile.user_id
-                )
+                Q(lists__is_private=False)
+                | Q(lists__owner=user_profile)
+                | Q(lists__teams__members__user_id=user_profile.user_id)
             ).distinct()
 
-        return TwitterAccount.objects.filter(lists__is_private=False)
+        return TwitterAccount.objects.filter(lists__is_private=False).distinct()
 
 
 class TwitterAccountCategoriesView(generics.ListAPIView):


### PR DESCRIPTION
## Description

Return Twitter accounts belonging to public lists even to non-logged-in users

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Screenshots

#### Logged in User
![Screenshot 2022-01-12 at 16 10 02](https://user-images.githubusercontent.com/13068580/149146509-97d3daa7-97ce-4192-84e3-3ceef16fea21.png)

#### Non Loggedin User
![Screenshot 2022-01-12 at 16 10 39](https://user-images.githubusercontent.com/13068580/149146636-31ae7e9e-c7d3-4133-bbc7-20b619ac5977.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
