### PR TITLE
Fix No Attribute error

### DIFF
--- a/twoopstracker/twoops/serializers.py
+++ b/twoopstracker/twoops/serializers.py
@@ -94,7 +94,8 @@ class TwitterAccountsListSerializer(TwitterAccountsListsSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
-        if self.context.get("request", {}).GET.get("download"):
+        request = self.context.get("request")
+        if hasattr(request, "GET") and request.GET.get("download"):
             data["accounts"] = self.get_accounts(instance)
         else:
             data.pop("accounts", None)


### PR DESCRIPTION
## Description
Fixes error introduced on this [PR](https://github.com/CodeForAfrica/TwoopsTracker/pull/46) where a dict was being returned as the default value in case request was missing from the context. `GET` attribute doesn't exist in `dict` thus the error

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
