### PR TITLE
[Feature] Allow ordering of `/v1/accounts`

### DIFF
--- a/twoopstracker/twoops/urls.py
+++ b/twoopstracker/twoops/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         "lists/upload", AccountsListUploadAPIView.as_view(), name="accounts_list_upload"
     ),
     path("lists/<pk>", AccountsList.as_view(), name="acccounts_list-detail"),
-    path("accounts/", TwitterAccountsView.as_view(), name="accounts"),
+    path("accounts/", TwitterAccountsView.as_view(), name="tweeter_account-list"),
     path(
         "accounts/categories/",
         TwitterAccountCategoriesView.as_view(),

--- a/twoopstracker/twoops/urls.py
+++ b/twoopstracker/twoops/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         "lists/upload", AccountsListUploadAPIView.as_view(), name="accounts_list_upload"
     ),
     path("lists/<pk>", AccountsList.as_view(), name="acccounts_list-detail"),
-    path("accounts/", TwitterAccountsView.as_view(), name="tweeter_account-list"),
+    path("accounts/", TwitterAccountsView.as_view(), name="twitter_account-list"),
     path(
         "accounts/categories/",
         TwitterAccountCategoriesView.as_view(),

--- a/twoopstracker/twoops/views.py
+++ b/twoopstracker/twoops/views.py
@@ -430,6 +430,9 @@ class AccountsList(generics.RetrieveUpdateDestroyAPIView):
 
 class TwitterAccountsView(generics.ListAPIView):
     serializer_class = TwitterAccountsSerializer
+    filter_backends = (filters.OrderingFilter,)
+    ordering_fields = ["name", "screen_name", "created_at"]
+    ordering = ["name"]
 
     def get_queryset(self):
         filter_ids = Q()


### PR DESCRIPTION
## Description

Allow ordering of `/v1/accounts` for the UI to match designs.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot from 2022-02-14 11-24-26](https://user-images.githubusercontent.com/1779590/153826790-d7ecc9a4-60bd-4176-ba66-6787b4cb697c.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
